### PR TITLE
explicitly require `dotenv`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start-prod": "node -r dotenv/config ./src/server.js",
-    "start-dev": "nodemon -r dotenv/config ./src/server.js",
+    "start-prod": "node ./src/server.js",
+    "start-dev": "nodemon ./src/server.js",
     "migrate": "node-pg-migrate"
   },
   "repository": {

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const Hapi = require('@hapi/hapi');
 const Inert = require('@hapi/inert');
 


### PR DESCRIPTION
The package were required via npm scripts using `node -r dotnv/config main.js`. Now it is required explicitly, written in the main code base